### PR TITLE
Parameters for `env.catalog`

### DIFF
--- a/Pantograph/Protocol.lean
+++ b/Pantograph/Protocol.lean
@@ -162,6 +162,9 @@ structure EnvModuleReadResult where
 
 -- Print all symbols in environment
 structure EnvCatalog where
+  inclPrefixes: Option (List String)
+  exclPrefixes: List String
+  limit: Option Nat
   deriving FromJson
 structure EnvCatalogResult where
   symbols: Array String

--- a/Repl.lean
+++ b/Repl.lean
@@ -105,12 +105,25 @@ def liftTermElabM { α } (termElabM : Elab.TermElabM α) (levelNames : List Name
 
 section Environment
 
-def env_catalog (_ : Protocol.EnvCatalog) : EMainM Protocol.EnvCatalogResult := runCoreM do
+def env_catalog (args : Protocol.EnvCatalog) : EMainM Protocol.EnvCatalogResult := runCoreM do
   let env ← MonadEnv.getEnv
   let names := env.constants.fold (init := #[]) λ acc name info =>
     match toFilteredSymbol name info with
     | .some x => acc.push x
     | .none => acc
+  -- filter names by prefixes user has requested
+  let names :=
+     if let .some inclPrefixes := args.inclPrefixes
+     then names.filter (fun (name: String) => inclPrefixes.any (name.startsWith ·))
+     else names
+  -- filter out any names explicitly excluded
+  let names :=
+      names.filter (fun name => ! args.exclPrefixes.any (name.startsWith ·))
+  --  if user has supplied a limit, limit by the first <limit> names
+  let names :=
+     if let .some limit := args.limit
+     then names.take limit
+     else names
   return { symbols := names }
 def env_inspect (args : Protocol.EnvInspect) : EMainM Protocol.EnvInspectResult := do
   let env ← MonadEnv.getEnv


### PR DESCRIPTION
Hi! Apologies for the errant PR. Feel free to close if this isn't the direction you're thinking of for this API. I was playing around with pantograph/pypantograph, and I wanted to call `env.catalog` from Python. 

The only problem is that without further filtering and limiting, the number of elements in the returned list is too long and causes the `proc.stdout.read_line` to raise an exception:
```bash
ValueError: Separator is not found, and chunk exceed the limit
```

This PR adds three parameters to customise the behaviour of env.catalog:
- `limit` - if supplied, limits the number of names to at most `limit`
- `inclPrefixes` - if supplied, only returns names matching any of the inclPrefixes
- `exclPrefixes` - all returned names will be guaranteed to not have prefixes in this list

This PR preserves the previous behavior of `env.catalog` if these parameters are not supplied then the behaviour is as before, including raising `ValueError`.

There is a corresponding PR in PyPantograph to expose env.catalog with these parameters.