### PR TITLE
Proposal for a `frontend.eval` command

### DIFF
--- a/Pantograph/Protocol.lean
+++ b/Pantograph/Protocol.lean
@@ -428,6 +428,15 @@ structure FrontendProcessResult where
   units: List CompilationUnit
   deriving ToJson
 
+/-- Frontend eval expression -/
+structure FrontendEval where
+  expr: String
+  bang: Bool := .false
+  deriving FromJson
+structure FrontendEvalResult where
+  messages: Array Lean.SerialMessage
+  deriving ToJson
+
 /-- Frontend Process's side output going into a file -/
 structure FrontendDataUnit where
   invocations? : Option (List Protocol.InvokedTactic) := .none

--- a/Repl.lean
+++ b/Repl.lean
@@ -420,6 +420,26 @@ def frontend_process (args : Protocol.FrontendProcess) : EMainM Protocol.Fronten
     }
   return { units }
 
+def frontend_eval (args: Protocol.FrontendEval) : EMainM Protocol.FrontendEvalResult := do
+  let msgs ← liftTermElabM do
+      let expr ← match Parser.runParserCategory
+            (env := ← MonadEnv.getEnv)
+            (catName := `term)
+            (input := args.expr)
+            (fileName := ← getFileName) with
+        | .ok syn => pure syn
+        | .error error => throwError "Failed to parse: {error}"
+      let msgs <- liftCommandElabM do
+         let noMsgs := (<- get).messages.toArray.size
+         Lean.Elab.Command.elabEvalCore args.bang expr expr .none
+         let s' <- get
+         pure $ s'.messages.toArray.drop noMsgs
+      return msgs
+  let messages <- msgs.mapM (·.serialize)
+  return {
+     messages := messages
+  }
+
 end Frontend
 
 /-- Main loop command of the REPL -/
@@ -461,6 +481,7 @@ def execute (command : Protocol.Command) : MainM Json := do
   | "goal.print"    => run goal_print
   | "goal.save"     => run goal_save
   | "goal.load"     => run goal_load
+  | "frontend.eval"          => run frontend_eval
   | "frontend.process" => run frontend_process
   | "frontend.distil"  => run frontend_distil
   | "frontend.track"   => run frontend_track


### PR DESCRIPTION
This PR adds a command `frontend.eval` to the pantograph server. The main motivation for this is that it would be nice to run things like:

```python
from pantograph import Server

def fib(n: int) -> int:
    if n < 2:
        return 1
    return fib(n - 1) + fib(n - 2)

server = Server()
server.load_definitions("""
partial def fib : Nat -> Nat
| 0 | 1 => 1
| n => fib (n - 1) + fib (n - 2)
""")

assert [int(server.eval(f"fib {i}", bang=True)) for i in range(10)] == [
    fib(i) for i in range(10)
]
```