### PR TITLE
fix: correct empty substring check for Substring.Raw type

### DIFF
--- a/Pantograph/Frontend/Basic.lean
+++ b/Pantograph/Frontend/Basic.lean
@@ -131,7 +131,7 @@ partial def executeFrontend { m } [Monad m] [MonadLiftT FrontendM m]
   (f : CompilationStep → m Unit) : m Unit := do
   let (cmd, done) ← processOneCommand
   if done then
-    if cmd.src.str.isEmpty then
+    if cmd.src.startPos == cmd.src.stopPos then
       return ()
     else
       f cmd


### PR DESCRIPTION
The check for empty compilation steps was using `cmd.src.str.isEmpty` which checks if the underlying string is empty, but for `Substring.Raw` we need to check if `startPos == stopPos` to determine if the substring is empty.